### PR TITLE
wpt migration: update GitHub repo and org names

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -1,7 +1,7 @@
 "use strict";
 var token = process.env.GITHUB_TOKEN;
-var repo = "web-platform-tests";
-var owner = "w3c";
+var repo = "wpt";
+var owner = "web-platform-tests";
 var request = require('request'),
     q = require('q');
 

--- a/lib/test-urls-comment.js
+++ b/lib/test-urls-comment.js
@@ -6,7 +6,7 @@ module.exports = function(number, metadata) {
     if (metadata.authorIsCollaborator) {
         body = "These tests will be available shortly on [w3c-test.org](" + BASE_TEST_URL + number + "/).";
     } else {
-        body = "These tests will be available on [w3c-test.org](" + BASE_TEST_URL + number + "/) shortly after they are [approved](https://github.com/w3c/web-platform-tests/blob/master/README.md#publication) by a repository collaborator.";
+        body = "These tests will be available on [w3c-test.org](" + BASE_TEST_URL + number + "/) shortly after they are [approved](https://github.com/web-platform-tests/wpt/blob/master/README.md#publication) by a repository collaborator.";
     }
     if (metadata.testUrls.length) {
         body += "\n\n" + metadata.testUrls.map(function(url) {


### PR DESCRIPTION
This needs to be merged post wpt migration to ensure reviewers are still notified of new pull requests.