### PR TITLE
Run tests in latest version of Node.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 sudo: false
 language: node_js
 node_js:
-  - 4.8.4
+  - 8


### PR DESCRIPTION
Node.js version 4 has reached the end of its support cycle. Version 8 is
the current LTS release.