### PR TITLE
Add PATCH method to github API lib

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -28,6 +28,10 @@ function put(url, body, options) {
     return _post("PUT", url, body, options);
 }
 
+function patch(url, body, options) {
+    return _post("PATCH", url, body, options);
+}
+
 function _post(method, url, body, options) {
     options = mergeOptions(options || {});
     url = replaceURL(baseURL(url), options);
@@ -126,3 +130,4 @@ function replaceURL(url, options) {
 exports.get = get;
 exports.post = post;
 exports.put = put;
+exports.patch = patch;


### PR DESCRIPTION
This is towards #41. The intention is to use the [Update a reference](https://developer.github.com/v3/git/refs/#update-a-reference) GitHub API to update branches triggered by the wpt.fyi revision announcer (see web-platform-tests/wpt.fyi#551 for tracking announcer changes towards this).