### PR TITLE
Implement epochal update hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,8 +140,15 @@ var updateEpoch = function (epoch) {
 
     logArgs("Updating epoch", epoch);
 
-    // Defer to epochs library for update.
-    epochs.updateEpoch(epoch).then(function (next) {
+    // Timeout update operation after 1.5 minutes.
+    var timeout = q.defer();
+    setTimeout(timeout.reject.bind(timeout,
+            new Error(`Epoch update for ${epoch} timed out`)),
+        90 * 1000);
+    q.promise.race([
+        // Defer to epochs library for update.
+        epochs.updateEpoch(epoch), timeout
+    ]).then(function (next) {
         delete inFlightEpochs[epoch];
         logArgs("Updated epoch", epoch, next);
     }, function (err) {

--- a/lib/epochs.js
+++ b/lib/epochs.js
@@ -1,0 +1,70 @@
+"use strict";
+
+var github = require('./github'),
+    request = require('request'),
+    q = require('q');
+
+function updateEpoch(epoch) {
+    // Trust fresh GET from epochs API to deliver latest hash.
+    var deferred = q.defer();
+    request.get('https://wpt.fyi/api/revisions/latest', function (err, response, body) {
+        if (err) {
+            deferred.reject(err);
+            return;
+        }
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+            deferred.reject(new Error("Bad status code from epochs API: " +
+                response.statusCode));
+            return;
+        }
+        body = JSON.parse(body || "null");
+        if (!body) {
+            deferred.reject(new Error("Falsey epochs API response body"));
+            return;
+        }
+        if (!body.revisions) {
+            deferred.reject(new Error("Epochs API body missing 'revisions' key"));
+            return;
+        }
+        if (!body.revisions[epoch]) {
+            deferred.reject(new Error("Epochs API body missing 'revisions.[epoch]' key"));
+            return;
+        }
+        if (!body.revisions[epoch].hash) {
+            deferred.reject(new Error("Epochs API body missing 'revisions.[epoch].hash"));
+            return;
+        }
+        deferred.resolve(body.revisions[epoch].hash);
+    });
+
+    // Update epochs/[epoch] branch ref iff it has changed.
+    var ref = 'heads/epochs/' + epoch;
+    return deferred.promise.then(function (next) {
+        return github.get('/repos/:owner/:repo/git/refs/:ref', {
+            ref: ref
+        }).then(function (body) {
+            if (!body) {
+                throw new Error("Falsey get ref response body");
+            }
+            if (!body.object) {
+                throw new Error("Get ref response body missing 'object' key");
+            }
+            if (!body.object.sha) {
+                throw new Error("Get ref response body missing 'object.sha' key");
+            }
+            var prev = body.object.sha;
+            if (prev === next) {
+                throw new Error("Expected ref hash to have changed, but it has not");
+            }
+
+            return github.patch('/repos/:owner/:repo/git/refs/:ref', {
+                sha: next,
+                force: true
+            }, { ref: ref });
+        }).then(function () {
+            return next;
+        });
+    });
+}
+
+exports.updateEpoch = updateEpoch;


### PR DESCRIPTION
This introduces a new `/update-epoch` endpoint that updates the `epochs/[epoch]` branch ref in `web-platform-tests/wpt` iff it has changed.

The request format expected from the wpt.fyi revision announcer is verified, but no authentication is required; the revision announcer API (rather than the incoming request body) is trusted to deliver an accurate epochal hash.

This is towards #41 and web-platform-tests/wpt.fyi#551.

CC @foolip 