### PR TITLE
Deploy to Node.js version 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "author": "Tobie Langel",
   "subdomain": "ganesh",
   "engines": {
-    "node": "4.8.4"
+    "node": "8.x.x"
   }
 }


### PR DESCRIPTION
Node.js version 4 reached end-of-life on April 2018 [1]. Update to
version 8, the latest LTS relase, due to receive support until December
2019.

[1] https://github.com/nodejs/Release/tree/19985fe7c16c764805bed84ea4901488bec35cbf#release-schedule

---

Note that merging this patch will trigger re-deployment. Test coverage isn't great in this project, so maintainers should actively monitor performance following the merge.