### PR TITLE
Automtically approve CSS patches from CSS editors

### DIFF
--- a/lib/approve.js
+++ b/lib/approve.js
@@ -1,0 +1,24 @@
+'use strict';
+var github = require('./github');
+
+module.exports = function(number, reason) {
+    return github.get('/repos/:owner/:repo/pulls/:number/reviews', { number: number })
+        .then(function(reviews) {
+            var isReviewed = reviews.some(function(r) {
+                return r.user.login == 'wpt-pr-bot';
+            });
+
+            if (isReviewed) {
+                return false;
+            }
+
+            return github.post('/repos/:owner/:repo/pulls/:number/reviews', {
+                    body: reason,
+                    event: 'APPROVE',
+                    comments: []
+                }, { number: number })
+                .then(function() {
+                    return true;
+                });
+        });
+};

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -1,6 +1,7 @@
 "use strict";
 var github = require('./github');
 var q = require('q');
+var approve = require('./approve');
 var labelModel = require("./label-model");
 var isProcessed = require("./is-processed");
 
@@ -11,21 +12,9 @@ function promise(value) {
 }
 
 module.exports = function(number, metadata) {
+    // Auto-approve PR that have been reviewed downstream.
     if (metadata.reviewedDownstream) {
-        // Auto-approve PR that have been reviewed downstream.
-        return github.get('/repos/:owner/:repo/pulls/:number/reviews', { number: number }).then(function(requests) {
-            var isReviewed = requests.some(function(r) {
-                return r.user.login == "wpt-pr-bot";
-            });
-
-            if (!isReviewed) {
-                return github.post('/repos/:owner/:repo/pulls/:number/reviews', {
-                    body: "Already reviewed downstream.",
-                    event: "APPROVE",
-                    comments: []
-                }, { number: number });
-            }
-        });
+        return approve(number, 'Already reviewed downstream.');
     }
 
     // if there are collaborators, we ask them for a review

--- a/lib/comment.js
+++ b/lib/comment.js
@@ -11,10 +11,27 @@ function promise(value) {
     return deferred.promise;
 }
 
+var cssEditors = ['fantasai', 'frivoal' 'tabatkins'];
+
+function isExpeditedCss(metadata) {
+    return cssEditors.includes(metadata.author.login) &&
+        metadata.filenames.every(function(filename) {
+            return /^css\//.test(filename);
+        });
+}
+
 module.exports = function(number, metadata) {
     // Auto-approve PR that have been reviewed downstream.
     if (metadata.reviewedDownstream) {
         return approve(number, 'Already reviewed downstream.');
+    }
+
+    if (isExpeditedCss(metadata)) {
+        return approve(
+            number,
+            '[Peer review is not required for CSS editors.]' +
+                '(https://www.w3.org/2018/10/22-css-minutes.html#item20)'
+        );
     }
 
     // if there are collaborators, we ask them for a review

--- a/test/approve.js
+++ b/test/approve.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var assert = require('chai').assert,
+    approve = require('../lib/approve');
+
+suite('approve', function() {
+    test('submits review for pull request with zero reviews', function() {
+        // This issue number does not describe a GitHub pull request. The
+        // corresponding fixture data has been manually altered to simulate
+        // expected interation with GitHub.com
+        return approve(13976, 'I felt like it')
+            .then(function(result) {
+                assert.equal(result, true);
+            });
+    });
+
+    test('does not submit review multiple times', function() {
+        return approve(13990, 'I felt like it')
+            .then(function(result) {
+                assert.equal(result, false);
+            });
+    });
+});

--- a/test/fixtures/api.github.com-443/154172730455410951
+++ b/test/fixtures/api.github.com-443/154172730455410951
@@ -1,0 +1,31 @@
+GET /repos/web-platform-tests/wpt/pulls/13990/reviews
+accept: application/vnd.github.black-cat-preview+json
+host: api.github.com
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[{"id":173186207,"node_id":"MDE3OlB1bGxSZXF1ZXN0UmV2aWV3MTczMTg2MjA3","user":{"login":"wpt-pr-bot","id":16780864,"node_id":"MDQ6VXNlcjE2NzgwODY0","avatar_url":"https://avatars3.githubusercontent.com/u/16780864?v=4","gravatar_id":"","url":"https://api.github.com/users/wpt-pr-bot","html_url":"https://github.com/wpt-pr-bot","followers_url":"https://api.github.com/users/wpt-pr-bot/followers","following_url":"https://api.github.com/users/wpt-pr-bot/following{/other_user}","gists_url":"https://api.github.com/users/wpt-pr-bot/gists{/gist_id}","starred_url":"https://api.github.com/users/wpt-pr-bot/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/wpt-pr-bot/subscriptions","organizations_url":"https://api.github.com/users/wpt-pr-bot/orgs","repos_url":"https://api.github.com/users/wpt-pr-bot/repos","events_url":"https://api.github.com/users/wpt-pr-bot/events{/privacy}","received_events_url":"https://api.github.com/users/wpt-pr-bot/received_events","type":"User","site_admin":false},"body":"Already reviewed downstream.","state":"APPROVED","html_url":"https://github.com/web-platform-tests/wpt/pull/13990#pullrequestreview-173186207","pull_request_url":"https://api.github.com/repos/web-platform-tests/wpt/pulls/13990","author_association":"COLLABORATOR","_links":{"html":{"href":"https://github.com/web-platform-tests/wpt/pull/13990#pullrequestreview-173186207"},"pull_request":{"href":"https://api.github.com/repos/web-platform-tests/wpt/pulls/13990"}},"submitted_at":"2018-11-08T21:43:25Z","commit_id":"cee3c69216627203789f37a1c58f0351bdb112ce"}]

--- a/test/fixtures/api.github.com-443/approve-fake-pr-read
+++ b/test/fixtures/api.github.com-443/approve-fake-pr-read
@@ -1,0 +1,31 @@
+GET /repos/web-platform-tests/wpt/pulls/13976/reviews
+accept: application/vnd.github.black-cat-preview+json
+host: api.github.com
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/approve-fake-pr-update
+++ b/test/fixtures/api.github.com-443/approve-fake-pr-update
@@ -1,0 +1,29 @@
+POST /repos/web-platform-tests/wpt/pulls/13976/reviews
+accept: application/vnd.github.black-cat-preview+json
+host: api.github.com
+body: {\"body\":\"I felt like it\",\"event\":\"APPROVE\",\"comments\":[]}
+
+HTTP/1.1 200 Okay
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:39:31 GMT
+content-type: application/json; charset=utf-8
+content-length: 2
+connection: close
+status: 200 Okay
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4996
+x-ratelimit-reset: 1541729149
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: repo
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D05A:6FD7:4A0FCCA:9AB6F49:5BE4E553
+
+{}


### PR DESCRIPTION
This patch is intentionally circumscribed to the requirements defined at TPAC
2018. A more dynamic solution involving flat files maintained within WPT (as
suggested by @gsnedders above) will be preferable if this functionality is
deemed appropriate for wider use. For the time being, we should consider this a
pragmatic compromise to address a non-technical problem.

I would like to get @jgraham's input before merging this since James wasn't
present in the TPAC discussion.