### PR TITLE
Assign the last reviewer if applicable

### DIFF
--- a/lib/metadata/choose-assignee.js
+++ b/lib/metadata/choose-assignee.js
@@ -6,11 +6,20 @@ module.exports = function chooseAssignee(number, metadata) {
     if (issue.assignee) {
       return null;
     }
-    var reviewers = metadata.reviewersExcludingAuthor;
-    if (!reviewers.length) {
-      return null;
-    }
-    var index = Math.floor(Math.random() * reviewers.length);
-    return reviewers[index].login;
+    // Check for existing reviews and grab the reviewer who "touched it last".
+    return github.get('/repos/:owner/:repo/pulls/:number/reviews', {number: number}).then(function(reviews) {
+      let assignee = null;
+      if (reviews && reviews.length) {
+        assignee = reviews[reviews.length - 1].user.login;
+      }
+      if (!assignee) {
+        var reviewers = metadata.reviewersExcludingAuthor;
+        if (reviewers.length) {
+          var index = Math.floor(Math.random() * reviewers.length);
+          return reviewers[index].login;
+        }
+      }
+      return assignee;
+    });
   });
 };

--- a/test/get-metadata.js
+++ b/test/get-metadata.js
@@ -75,7 +75,7 @@ suite('getMetadata', function() {
             reviewers: [ 'domenic', 'jensl', 'ms2ger', 'tobie', 'yuki3' ],
             isMergeable: true,
             reviewedDownstream: false,
-            missingAssignee: 'jensl',
+            missingAssignee: 'Ms2ger',
             missingReviewers: [],
         };
 


### PR DESCRIPTION
For the ~500 or so already-existing PRs, a random assignee isn't a great pick.
This changes the assignment to check for existing reviews, and assigns the most recent reviewer if there are any.