### PR TITLE
Also update epochs/twelve_hourly and epochs/six_hourly branches

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ app.post('/github-hook', function (req, res, next) {
     }));
 });
 
-var knownEpochs = [ 'weekly', 'daily' ];
+var knownEpochs = [ 'weekly', 'daily', 'twelve_hourly', 'six_hourly' ];
 var inFlightEpochs = {};
 var updateEpoch = function (epoch) {
     if (inFlightEpochs[epoch]) {


### PR DESCRIPTION
After https://github.com/web-platform-tests/wpt/issues/14836,
Safari Technology Preview runs are completing in ~1.5h. This makes it feasible
to run more frequently, so sync the 12- and 6-hour epoch branches too.