### PR TITLE
Improve comment describing downstream review

### DIFF
--- a/lib/comment.js
+++ b/lib/comment.js
@@ -23,7 +23,11 @@ function isExpeditedCss(metadata) {
 module.exports = function(number, metadata) {
     // Auto-approve PR that have been reviewed downstream.
     if (metadata.reviewedDownstream) {
-        return approve(number, 'Already reviewed downstream.');
+        return approve(
+            number,
+            'The review process for this patch is being conducted in the ' +
+                metadata.reviewedDownstream + ' project.'
+        );
     }
 
     if (isExpeditedCss(metadata)) {

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -12,6 +12,32 @@ var filenames = require('./filenames'),
     chooseAssignee = require('./choose-assignee'),
     github = require('../github');
 
+function inferDownstreamReview(metadata, content) {
+    var login = metadata.author.login;
+
+    if (login == "chromium-wpt-export-bot") {
+        return "Chromium";
+    }
+
+    if (login == "servo-wpt-sync") {
+        return "Servo";
+    }
+
+    if (login == "moz-wptsync-bot" ||
+        (login == "jgraham" && content.indexOf("MozReview-Commit-ID") > -1) ||
+        (login == "dbaron" && content.indexOf("Sync Mozilla CSS tests") > -1)) {
+        return "Firefox";
+    }
+
+    if (content.indexOf("WebKit export") > -1 &&
+        (login == "fwang" || login == "ms2ger" || login == "rniwa" ||
+        login == "youennf")) {
+        return "WebKit";
+    }
+
+    return null;
+}
+
 module.exports = function getMetadada(number, author, content) {
     var metadata = {
         issue: number,
@@ -97,12 +123,8 @@ module.exports = function getMetadada(number, author, content) {
                     return owner.permission == "admin" || owner.permission == "write";
                 });
             // The above is missing the case where a reviewer which has write permission and is not an owner was added.
-            metadata.reviewedDownstream = (metadata.author.login == "chromium-wpt-export-bot") ||
-                (metadata.author.login == "servo-wpt-sync") ||
-                (metadata.author.login == "moz-wptsync-bot") ||
-                ((metadata.author.login == "fwang" || metadata.author.login == "ms2ger" || metadata.author.login == "rniwa" || metadata.author.login == "youennf") && content.indexOf("WebKit export") > -1) ||
-                (metadata.author.login == "jgraham" && content.indexOf("MozReview-Commit-ID") > -1) ||
-                (metadata.author.login == "dbaron" && content.indexOf("Sync Mozilla CSS tests") > -1);
+
+            metadata.reviewedDownstream = inferDownstreamReview(metadata, content);
 
             metadata.missingReviewers = getReviewers(metadata);
 

--- a/test/get-metadata.js
+++ b/test/get-metadata.js
@@ -115,7 +115,7 @@ suite('getMetadata', function() {
             ],
             reviewers: [ 'domenic', 'jensl', 'ms2ger', 'tobie', 'yuki3' ],
             isMergeable: true,
-            reviewedDownstream: false,
+            reviewedDownstream: null,
             missingAssignee: 'Ms2ger',
             missingReviewers: [],
         };
@@ -177,7 +177,7 @@ suite('getMetadata', function() {
             "svg/coordinate-systems",
             "svg/coordinate-systems/parsing",
           ],
-          reviewedDownstream: false,
+          reviewedDownstream: null,
           reviewers: [
             "ameliabr",
             "ewilligers",


### PR DESCRIPTION
Some downstream projects create a pull request before code review has
been completed [1]. Update the generated comment to avoid suggesting
otherwise, and extend with the name of the downstream project where
review is under way.

[1] https://github.com/servo/servo/pull/22809#issuecomment-459963112