### PR TITLE
React when draft pull requests are marked "ready"

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,7 +100,9 @@ app.post('/github-hook', function (req, res, next) {
                 metadata(n, u, content).then(function(metadata) {
                     return removeReviewableBanner(n, metadata);
                 });
-            } else if (action == "opened" || action == "synchronize" || (isComment && action == "created")) {
+            } else if (action == "opened" || action == "synchronize" ||
+                action == "ready_for_review" ||
+                (isComment && action == "created")) {
                 if (n in currentlyRunning) {
                     logArgs("#" + n + " is already being processed.");
                     return;


### PR DESCRIPTION
GitHub recently added support for "draft" pull requests, and this
project subsequently began ignoring them upon creation [2]. Complete the
implementation of that change by recognizing when "drafts" move to a
"ready" state and acting on the pull request.

[1] https://github.blog/2019-02-14-introducing-draft-pull-requests/
[2] cd003b22152c06661949292f06270026b78e59d3