### PR TITLE
Add the `repository` field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "wpt-pr-bot",
   "version": "0.4.0",
   "description": "A helper bot for web-platform-tests.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-platform-tests/wpt-pr-bot.git"
+  },
   "main": "index.js",
   "scripts": {
     "test": "mocha -u tdd ./test/setup.js ./test/*.js",


### PR DESCRIPTION
Avoids this warning from `npm install`:
> npm WARN wpt-pr-bot@0.4.0 No repository field.