### PR TITLE
Extract event and pull request filtering and attempt to make robust

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -1,0 +1,32 @@
+"use strict";
+
+// Filter functions for GitHub API responses. Returns true if the entity passes
+// the filter, like a `Array.prototype.filter` callback. The `log` callback is
+// called with any console messages that should be logged.
+
+function filterEvent(body, log) {
+    if (!body) {
+        log("Ignoring event: no body");
+        return false;
+    }
+    if (body.sender && body.sender.login == "wpt-pr-bot") {
+        log("Ignoring event: sender is wpt-pr-bot");
+        return false;
+    }
+    return true;
+}
+
+function filterPullRequest(pull_request, log) {
+    if (pull_request.state == "closed") {
+        log(`Ignoring #${pull_request.number}: pull request is closed`);
+        return false;
+    }
+    if (pull_request.draft) {
+        log(`Ignoring #${pull_request.number}: pull request is a draft`);
+        return false;
+    }
+    return true;
+}
+
+exports.event = filterEvent;
+exports.pullRequest = filterPullRequest;

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const assert = require('assert'),
+      filter = require('../lib/filter');
+
+function nullLog() {
+    // Do nothing. Log messages could be verified but aren't.
+}
+
+suite('Event filtering', function() {
+    test('null body', function() {
+        assert.strictEqual(filter.event(null, nullLog), false);
+    });
+    test('empty body', function() {
+        assert.strictEqual(filter.event({}, nullLog), true);
+    });
+    test('wpt-pr-bot sender', function() {
+        assert.strictEqual(filter.event({
+            sender: {
+                login: 'wpt-pr-bot'
+            }
+        }, nullLog), false);
+    });
+    test('other sender', function() {
+        assert.strictEqual(filter.event({
+            sender: {
+                login: 'some-other-user'
+            }
+        }, nullLog), true);
+    });
+
+});
+
+suite('Pull request filtering', function() {
+    test('null payload', function() {
+        assert.throws(function() {
+            filter.pullRequest(null, nullLog);
+        });
+    });
+    test('empty payload', function() {
+        assert.strictEqual(filter.pullRequest({}, nullLog), true);
+    });
+    test('closed pull request', function() {
+        assert.strictEqual(filter.pullRequest({state: "closed"}, nullLog), false);
+    });
+    test('open pull request', function() {
+        assert.strictEqual(filter.pullRequest({state: "open"}, nullLog), true);
+    });
+    test('draft pull request', function() {
+        assert.strictEqual(filter.pullRequest({draft: true}, nullLog), false);
+    });
+    test('explicitly non-draft pull request', function() {
+        assert.strictEqual(filter.pullRequest({draft: false}, nullLog), true);
+    });
+});


### PR DESCRIPTION
This is not plain refactoring, as the `state == "closed"` condition
replaces the check on `merged`. It also ensures that we perform the
same checks both on the event payload and on the response from
https://developer.github.com/v3/pulls/#get-a-single-pull-request.

Fixes https://github.com/web-platform-tests/wpt-pr-bot/issues/38.
Fixes https://github.com/web-platform-tests/wpt-pr-bot/issues/69.