### PR TITLE
Pin dependencies to what `npm install` will currently install

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,20 +14,20 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "bl": "^1.0.0",
+    "bl": "1.2.2",
     "ent": "0.1.0",
-    "express": "4.x",
+    "express": "4.17.1",
     "js-yaml": "3.12.0",
-    "minimatch": "^3.0.4",
+    "minimatch": "3.0.4",
     "q": "1.0.0",
     "request": "2.48.0",
-    "sinon": "^7.1.1"
+    "sinon": "7.5.0"
   },
   "devDependencies": {
-    "chai": "^4.1.2",
-    "jshint": "^2.9.6",
+    "chai": "4.2.0",
+    "jshint": "2.10.2",
     "mocha": "1.21.4",
-    "replay": "^2.3.0"
+    "replay": "2.4.0"
   },
   "license": "Apache-2.0",
   "author": "Tobie Langel",


### PR DESCRIPTION
Running `npm install` with and without these changes results in
exactly the same node_modules tree.

There are no changes to package-lock.json.