### PR TITLE
Automatically label GitHub Actions PRs

### DIFF
--- a/lib/metadata/labels.js
+++ b/lib/metadata/labels.js
@@ -49,6 +49,7 @@ var LABEL_TO_PATTERNS = {
     "testdriver.js": ["resources/testdriver*"],
     "testharness.js": ["resources/testharness*", "resources/test/**"],
     "Azure Pipelines": [".azure-pipelines.yml", "tools/ci/azure/**"],
+    "GitHub Actions": [".github/**"],
     "Taskcluster": [".taskcluster.yml"]
 };
 var LABEL_TO_REGEXPS = Object.create(null);


### PR DESCRIPTION
There could be other things in .github/, but currently there isn't,
and matching everything avoid the .github label being recreated if
.github/META.yml is touched.

Like https://github.com/web-platform-tests/wpt-pr-bot/pull/64.