### PR TITLE
Also check `mergeable_state` to identify draft pull requests

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -21,7 +21,11 @@ function filterPullRequest(pull_request, log) {
         log(`Ignoring #${pull_request.number}: pull request is closed`);
         return false;
     }
-    if (pull_request.draft) {
+    // Note: the `draft` boolean is a preview API which we don't enable:
+    // https://developer.github.com/changes/2019-02-14-draft-pull-requests/
+    // The `mergeable_state` is undocumented but has been observed:
+    // https://github.com/web-platform-tests/wpt-pr-bot/issues/69#issuecomment-546273083
+    if (pull_request.draft || pull_request.mergeable_state === "draft") {
         log(`Ignoring #${pull_request.number}: pull request is a draft`);
         return false;
     }

--- a/test/filter.js
+++ b/test/filter.js
@@ -40,16 +40,22 @@ suite('Pull request filtering', function() {
     test('empty payload', function() {
         assert.strictEqual(filter.pullRequest({}, nullLog), true);
     });
-    test('closed pull request', function() {
+    test('`state` is "closed"', function() {
         assert.strictEqual(filter.pullRequest({state: "closed"}, nullLog), false);
     });
-    test('open pull request', function() {
+    test('`state` is "open"', function() {
         assert.strictEqual(filter.pullRequest({state: "open"}, nullLog), true);
     });
-    test('draft pull request', function() {
+    test('`draft` is true', function() {
         assert.strictEqual(filter.pullRequest({draft: true}, nullLog), false);
     });
-    test('explicitly non-draft pull request', function() {
+    test('`draft` is false', function() {
         assert.strictEqual(filter.pullRequest({draft: false}, nullLog), true);
+    });
+    test('`mergeable_state` is "draft"', function() {
+        assert.strictEqual(filter.pullRequest({mergeable_state: "draft"}, nullLog), false);
+    });
+    test('`mergeable_state` is "unknown"', function() {
+        assert.strictEqual(filter.pullRequest({mergeable_state: "unknown"}, nullLog), true);
     });
 });


### PR DESCRIPTION
This field can currently be observed here:
https://api.github.com/repos/web-platform-tests/wpt/pulls/19806

There's no stability guarantee here, it's a quickfix.

Fixes https://github.com/web-platform-tests/wpt-pr-bot/issues/69.