### PR TITLE
Remove unused dependency ent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -377,11 +377,6 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
-    "ent": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ent/-/ent-0.1.0.tgz",
-      "integrity": "sha1-3rnNfz2iWxqUwkjbvckdDwwJQDU="
-    },
     "entities": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "bl": "^1.0.0",
-    "ent": "0.1.0",
     "express": "4.x",
     "js-yaml": "3.12.0",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
It was introduced with commit b6fdf12f687b7c54a8469cfc3b21127253cb1404
for email notifications and later not removed with that feature in
commit d09a9d10a4c0dd923c0a89aae6263109e06cace7.