### PR TITLE
Migrate testing to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: test
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        node-version: ['8', '10']
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - 8
-notifications:
-  email:
-    on_success: never
-    on_failure: always


### PR DESCRIPTION
This is mostly to make the `npm test` explicit and make it easier
to add more jobs or steps. Also aligns with the wpt repo.