### PR TITLE
Run tests on Node.js 8+12 instead of 8+10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        node-version: ['8', '10']
+        node-version: ['8', '12']
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1


### PR DESCRIPTION
The deployment is still using 8, but 12 is now LTS and the version
we'd likely upgrade to, making it the more useful version to test.