### PR TITLE
Enable (dry-run guarded) code to comment/label WebKit exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,8 @@ app.listen(port, function() {
 // In addition to listening for notifications from GitHub, we regularly poll the
 // set of PRs to keep WebKit exports synchronized with the upstream PR.
 function pullRequestPoller() {
+    // TODO(smcgruer): Change this back to once per minute (to minimize latency)
+    // once we have fully launched WebKit export synchronization.
     waitFor(5 * 60 * 1000).then(function() {
         console.log('Checking for changes to WebKit-exported pull requests');
         github.get("/repos/:owner/:repo/pulls", {}).then(function (pull_requests) {

--- a/index.js
+++ b/index.js
@@ -135,7 +135,8 @@ app.listen(port, function() {
 // In addition to listening for notifications from GitHub, we regularly poll the
 // set of PRs to keep WebKit exports synchronized with the upstream PR.
 function pullRequestPoller() {
-    waitFor(60 * 1000).then(function() {
+    waitFor(5 * 60 * 1000).then(function() {
+        console.log('Checking for changes to WebKit-exported pull requests');
         github.get("/repos/:owner/:repo/pulls", {}).then(function (pull_requests) {
             pull_requests.forEach(function(pull_request) {
                 if (!webkit.related(pull_request.title)) {
@@ -158,16 +159,21 @@ function pullRequestPoller() {
                               console.log("  inCommit");
                         }
                     }
-                    // TODO: This part of the code must be uncommmented to
-                    /* return labelModel.post(n, metadata.labels, flags.get('dry-run')).then(
+                    // Hard-coded dry-run mode until we launch webkit-export
+                    // support in wpt-pr-bot
+                    const dryRun = true;
+                    const n = pull_request.number;
+                    return labelModel.post(n, metadata.labels, dryRun).then(
                          funkLogMsg(n, "Added missing LABELS if any."),
                          funkLogErr(n, "Something went wrong while adding missing LABELS.")
                     ).then(function() {
-                        return comment(n, metadata, flags.get('dry-run'));
+                        return comment(n, metadata, dryRun);
                     }).then(
                         funkLogMsg(n, "Added missing REVIEWERS if any."),
                         funkLogErr(n, "Something went wrong while adding missing REVIEWERS.")
-                    ); */
+                    );
+                }).catch(e => {
+                  console.log(e);
                 });
             });
             pullRequestPoller();


### PR DESCRIPTION
Currently the code is hard-coded to run in dry-run mode, until we've
proved out that it should do what we expect.

Also reduces the frequency from every minute to every 5 minutes, since
we will be doing the same thing over-and-over (since we're in dry-run
mode and so nothing will actually change).