### PR TITLE
Ship the webkit-export support

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,15 +161,12 @@ function pullRequestPoller() {
                               console.log("  inCommit");
                         }
                     }
-                    // Hard-coded dry-run mode until we launch webkit-export
-                    // support in wpt-pr-bot
-                    const dryRun = true;
                     const n = pull_request.number;
-                    return labelModel.post(n, metadata.labels, dryRun).then(
+                    return labelModel.post(n, metadata.labels, flags.get('dry-run')).then(
                          funkLogMsg(n, "Added missing LABELS if any."),
                          funkLogErr(n, "Something went wrong while adding missing LABELS.")
                     ).then(function() {
-                        return comment(n, metadata, dryRun);
+                        return comment(n, metadata, flags.get('dry-run'));
                     }).then(
                         funkLogMsg(n, "Added missing REVIEWERS if any."),
                         funkLogErr(n, "Something went wrong while adding missing REVIEWERS.")

--- a/lib/metadata/index.js
+++ b/lib/metadata/index.js
@@ -30,6 +30,11 @@ function inferDownstreamReview(metadata, content) {
         return "Firefox";
     }
 
+    // WebKit-exported PRs are only considered approved once they have a r+ on
+    // the WebKit side. Note that we treat approval as a one-way process; if we
+    // see r+ once, the PR will stay approved even if the r+ is later removed.
+    //
+    // https://hackmd.io/b4ViVtDsSk6Qg8fAycexVA#2-Getting-review-r-on-the-WebKit-patch-approves-the-export-PR
     if (metadata.isWebKitVerified && metadata.webkit.flags.reviewed) {
         return "WebKit";
     }


### PR DESCRIPTION
This removes the hard-coded dryRun flag for labelling and approving
WebKit-exported PRs, and uses the normal dry-run support instead.
Effectively, this launches the feature (since prod doesn't run in
dry-run mode!).

The 5-minute interval is left in place; I plan to remove it when we're
confident that the bot is doing the right thing.