### PR TITLE
Fix bug where webkit PRs are given assignees

### DIFF
--- a/lib/comment.js
+++ b/lib/comment.js
@@ -1,5 +1,3 @@
-// istanbul ignore file
-
 "use strict";
 
 var github = require('./github');
@@ -32,6 +30,7 @@ module.exports = async function(number, metadata, dryRun) {
     if (metadata.reviewedDownstream) {
         const message = 'The review process for this patch is being conducted in the ' +
             metadata.reviewedDownstream + ' project.';
+        // istanbul ignore if
         if (dryRun) {
             console.log(`[DRY-RUN] Would approve PR ${number} with message: ${message}`);
             return true;
@@ -40,10 +39,25 @@ module.exports = async function(number, metadata, dryRun) {
         return approve(number, message);
     }
 
+    // WebKit has a slightly different flow than other browser exports. The PR
+    // is not automatically approved; instead we wait for r+ downstream. In the
+    // meantime, we shouldn't assign anyone to it.
+    if (metadata.isWebKitVerified) {
+        const message = 'This patch has been exported from WebKit; it will be approved ' +
+            'automatically once the downstream patch is r+.';
+        // istanbul ignore if
+        if (dryRun) {
+            console.log(`[DRY-RUN] Would comment on PR ${number} with message: ${message}`);
+            return true;
+        }
+
+        return comment(number, message);
+    }
 
     if (isExpeditedCss(metadata)) {
         const message = '[Peer review is not required for CSS editors.]' +
             '(https://www.w3.org/2018/10/22-css-minutes.html#item20)';
+        // istanbul ignore if
         if (dryRun) {
             console.log(`[DRY-RUN] Would approve PR ${number} with message: ${message}`);
             return true;
@@ -53,6 +67,7 @@ module.exports = async function(number, metadata, dryRun) {
     }
 
     if (metadata.missingAssignee) {
+        // istanbul ignore if
         if (dryRun) {
             console.log(`[DRY-RUN] Would add assignee ${metadata.missingAssignee} to PR ${number}`);
         } else {
@@ -66,6 +81,7 @@ module.exports = async function(number, metadata, dryRun) {
         if (metadata.missingReviewers.length > 0) {
             const label = "status:needs-collaborator";
             const message = "No reviewer on this pull request has write-access to the repository.";
+            // istanbul ignore if
             if (dryRun) {
                 console.log(`[DRY-RUN] Would add reviewers ${metadata.missingReviewers} to PR ${number}`);
                 // Assume that adding reviewers would have succeeded.
@@ -94,6 +110,7 @@ module.exports = async function(number, metadata, dryRun) {
         // PR has reviewers, but nobody has write-access to the repo.
         const label = "status:needs-collaborator";
         const message = "No reviewer on this pull request has write-access to the repository.";
+        // istanbul ignore if
         if (dryRun) {
             console.log(`[DRY-RUN] Would add label "${label}" and comment "${message}" to PR ${number}`);
             return true;
@@ -104,6 +121,7 @@ module.exports = async function(number, metadata, dryRun) {
     if (metadata.author.isOwner) {
         const label = "status:needs-reviewers";
         const message = "There are no reviewers for this pull request besides its author.";
+        // istanbul ignore if
         if (dryRun) {
             console.log(`[DRY-RUN] Would add label "${label}" and comment "${message}" to PR ${number}`);
             return true;
@@ -113,6 +131,7 @@ module.exports = async function(number, metadata, dryRun) {
 
     const label = "status:needs-reviewers";
     const message = "There are no reviewers for this pull request.";
+    // istanbul ignore if
     if (dryRun) {
         console.log(`[DRY-RUN] Would add label "${label}" and comment "${message}" to PR ${number}`);
         return true;
@@ -124,9 +143,14 @@ async function labelAndComment(number, label, msg) {
     msg += " Please reach out on W3C's irc server (irc.w3.org, port 6665) on channel #testing ([web client](http://irc.w3.org/?channels=testing)) to get help with this. Thank you!";
     await labelModel.post(number, [label], /*dryRun*/ false);
 
+    return comment(number, msg);
+}
+
+async function comment(number, msg) {
     // Make sure we have not already commented on this PR.
     const processed = await isProcessed(number);
-    if (!processed) {
-        return github.post('/repos/:owner/:repo/issues/:number/comments', { body: msg }, { number: number });
+    if (processed) {
+        return false;
     }
+    return github.post('/repos/:owner/:repo/issues/:number/comments', { body: msg }, { number: number });
 }

--- a/test/comment.js
+++ b/test/comment.js
@@ -1,0 +1,162 @@
+'use strict';
+
+var assert = require('chai').assert,
+    comment = require('../lib/comment');
+
+suite('comment', function() {
+    test('approves exported PRs', async function() {
+        const metadata = {
+            author: { login: "someuser" },
+            reviewedDownstream: "Chromium",
+        };
+        // That the correct comment is made is enforced by the node-replay
+        // fixtures for this test: comment-exported-prs-*
+        const result = await comment(16780, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('comments but does not approve webkit-exported PRs', async function() {
+        // Exports from WebKit are only approved once they have r+ set
+        // downstream (at which point 'reviewedDownstream' will be set). In the
+        // meantime, we should not assign reviewers.
+        const metadata = {
+            author: { login: "someuser" },
+            isWebKitVerified: true,
+            reviewersExcludingAuthor: [],
+        };
+        // That the correct comment is made is enforced by the node-replay
+        // fixtures for this test: comment-webkit-prs-*
+        const result = await comment(16781, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('approves CSS editor PRs for css/ files', async function() {
+        const metadata = {
+            author: { login: 'frivoal', },
+            filenames: [ 'css/foo.html', ],
+        };
+        // That the correct comment is made is enforced by the node-replay
+        // fixtures for this test: comment-css-editor-pr-*
+        const result = await comment(16782, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('does not approve CSS editor PRs for non-css/ files', async function() {
+        const metadata = {
+            author: { login: 'frivoal', },
+            filenames: [ 'dom/bar.html', ],
+            reviewersExcludingAuthor: [],
+        };
+        // That the correct comment is made is enforced by the node-replay
+        // fixtures for this test: comment-css-editor-pr-non-css-file-*
+        const result = await comment(16783, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('adds missing assignee if there is one', async function() {
+        const metadata = {
+            author: { login: "someuser" },
+            missingAssignee: 'Hexcles',
+            reviewersExcludingAuthor: [],
+        };
+        // That the correct assignment and comment is made is enforced by the
+        // node-replay fixtures for this test: comment-missing-assignee-*
+        const result = await comment(16784, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('adds missing reviewers if needed', async function() {
+        const metadata = {
+            author: { login: "someuser" },
+            reviewersExcludingAuthor: ['stephenmcgruer'],
+            missingReviewers: ['stephenmcgruer'],
+            isMergeable: true,
+        };
+        // That the correct reviewers are added and NO comment is made is enforced
+        // by the node-replay fixtures for this test: comment-add-missing-reviewers-*
+        const result = await comment(16785, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('adds missing reviewers if needed, and comments if the PR is non-mergeable', async function() {
+        const metadata = {
+            author: { login: "someuser" },
+            reviewersExcludingAuthor: ['stephenmcgruer'],
+            missingReviewers: ['stephenmcgruer'],
+            isMergeable: false,
+        };
+        // That the correct reviewers are added and comment is made is enforced
+        // by the node-replay fixtures for this test:
+        // comment-add-missing-reviewers-not-mergeable-*
+        const result = await comment(16786, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('does nothing if we have all the reviewers and the PR is mergable', async function() {
+        const metadata = {
+            author: { login: "someuser" },
+            reviewersExcludingAuthor: ['stephenmcgruer'],
+            missingReviewers: [],
+            isMergeable: true,
+        };
+        // That no comment is made is enforced by the LACK of node-replay
+        // fixtures for this test.
+        const result = await comment(16787, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('handles the case where no reviewer has write-access to the repo', async function() {
+        const metadata = {
+            author: { login: "someuser" },
+            reviewersExcludingAuthor: ['someuser'],
+            missingReviewers: [],
+            isMergeable: false,
+        };
+        // That the correct comment is made is enforced by the node-replay
+        // fixtures for this test: comment-no-write-access-*
+        const result = await comment(16788, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('handles the case where the only reviewer is the author', async function() {
+        const metadata = {
+            reviewersExcludingAuthor: [],
+            author: {
+                login: 'stephenmcgruer',
+                isOwner: true,
+            }
+        };
+        // That the correct comment is made is enforced by the node-replay
+        // fixtures for this test: comment-author-is-reviewer-*
+        const result = await comment(16789, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('handles the case where there are no reviewers', async function() {
+        const metadata = {
+            reviewersExcludingAuthor: [],
+            author: {
+                login: 'someuser',
+                isOwner: false,
+            }
+        };
+        // That the correct comment is made is enforced by the node-replay
+        // fixtures for this test: comment-no-reviewers-*
+        const result = await comment(16790, metadata, false);
+        assert.equal(result, true);
+    });
+
+    test('does not comment twice', async function() {
+        const metadata = {
+            reviewersExcludingAuthor: [],
+            author: {
+                login: 'someuser',
+                isOwner: false,
+            }
+        };
+        // That a comment is not made is enforced by the node-replay
+        // fixtures for this test: comment-duplicate-comment-*
+        const result = await comment(16791, metadata, false);
+        assert.equal(result, false);
+    });
+});

--- a/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-get-comments
+++ b/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-get-comments
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16786/comments
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-get-labels
+++ b/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-get-labels
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16786/labels
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-post-comments
+++ b/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-post-comments
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16786/comments
+accept: application/vnd.github.black-cat-preview+json
+body: {\"body\":\"No reviewer on this pull request has write-access to the repository. Please reach out on W3C\'s irc server (irc.w3.org, port 6665) on channel #testing ([web client](http://irc.w3.org/?channels=testing)) to get help with this. Thank you!\"}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-post-labels
+++ b/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-post-labels
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16786/labels
+accept: application/vnd.github.black-cat-preview+json
+body: [\"status:needs-collaborator\"]
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+["status:needs-reviewers"]

--- a/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-post-requested-reviewers
+++ b/test/fixtures/api.github.com-443/comment-add-missing-reviewers-not-mergeable-post-requested-reviewers
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/pulls/16786/requested_reviewers
+accept: application/vnd.github.black-cat-preview+json
+body: {\"reviewers\":[\"stephenmcgruer\"]}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-add-missing-reviewers-post-requested-reviewers
+++ b/test/fixtures/api.github.com-443/comment-add-missing-reviewers-post-requested-reviewers
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/pulls/16785/requested_reviewers
+accept: application/vnd.github.black-cat-preview+json
+body: {\"reviewers\":[\"stephenmcgruer\"]}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-author-is-reviewer-get-comments
+++ b/test/fixtures/api.github.com-443/comment-author-is-reviewer-get-comments
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16789/comments
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-author-is-reviewer-get-labels
+++ b/test/fixtures/api.github.com-443/comment-author-is-reviewer-get-labels
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16789/labels
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-author-is-reviewer-post-comments
+++ b/test/fixtures/api.github.com-443/comment-author-is-reviewer-post-comments
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16789/comments
+accept: application/vnd.github.black-cat-preview+json
+body: {\"body\":\"There are no reviewers for this pull request besides its author. Please reach out on W3C\'s irc server (irc.w3.org, port 6665) on channel #testing ([web client](http://irc.w3.org/?channels=testing)) to get help with this. Thank you!\"}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-author-is-reviewer-post-labels
+++ b/test/fixtures/api.github.com-443/comment-author-is-reviewer-post-labels
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16789/labels
+accept: application/vnd.github.black-cat-preview+json
+body: [\"status:needs-reviewers\"]
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+["status:needs-reviewers"]

--- a/test/fixtures/api.github.com-443/comment-css-editor-pr-get-reviews
+++ b/test/fixtures/api.github.com-443/comment-css-editor-pr-get-reviews
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/pulls/16782/reviews
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-css-editor-pr-non-css-file-get-comments
+++ b/test/fixtures/api.github.com-443/comment-css-editor-pr-non-css-file-get-comments
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16783/comments
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-css-editor-pr-non-css-file-get-labels
+++ b/test/fixtures/api.github.com-443/comment-css-editor-pr-non-css-file-get-labels
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16783/labels
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-css-editor-pr-non-css-file-post-comments
+++ b/test/fixtures/api.github.com-443/comment-css-editor-pr-non-css-file-post-comments
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16783/comments
+accept: application/vnd.github.black-cat-preview+json
+body: {\"body\":\"There are no reviewers for this pull request. Please reach out on W3C\'s irc server (irc.w3.org, port 6665) on channel #testing ([web client](http://irc.w3.org/?channels=testing)) to get help with this. Thank you!\"}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-css-editor-pr-non-css-file-post-labels
+++ b/test/fixtures/api.github.com-443/comment-css-editor-pr-non-css-file-post-labels
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16783/labels
+accept: application/vnd.github.black-cat-preview+json
+body: [\"status:needs-reviewers\"]
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+["status:needs-reviewers"]

--- a/test/fixtures/api.github.com-443/comment-css-editor-pr-post-reviews
+++ b/test/fixtures/api.github.com-443/comment-css-editor-pr-post-reviews
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/pulls/16782/reviews
+accept: application/vnd.github.black-cat-preview+json
+body: {\"body\":\"[Peer review is not required for CSS editors.](https://www.w3.org/2018/10/22-css-minutes.html#item20)\",\"event\":\"APPROVE\",\"comments\":[]}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-duplicate-comment-get-comments
+++ b/test/fixtures/api.github.com-443/comment-duplicate-comment-get-comments
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16791/comments
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[{"user":{"login":"wpt-pr-bot"}}]

--- a/test/fixtures/api.github.com-443/comment-duplicate-comment-get-labels
+++ b/test/fixtures/api.github.com-443/comment-duplicate-comment-get-labels
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16791/labels
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-duplicate-comment-post-labels
+++ b/test/fixtures/api.github.com-443/comment-duplicate-comment-post-labels
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16791/labels
+accept: application/vnd.github.black-cat-preview+json
+body: [\"status:needs-reviewers\"]
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+["status:needs-reviewers"]

--- a/test/fixtures/api.github.com-443/comment-exported-prs-get-reviews
+++ b/test/fixtures/api.github.com-443/comment-exported-prs-get-reviews
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/pulls/16780/reviews
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-exported-prs-post-reviews
+++ b/test/fixtures/api.github.com-443/comment-exported-prs-post-reviews
@@ -1,0 +1,28 @@
+POST /repos/web-platform-tests/wpt/pulls/16780/reviews
+accept: application/vnd.github.black-cat-preview+json
+body: {\"body\":\"The review process for this patch is being conducted in the Chromium project.\",\"event\":\"APPROVE\",\"comments\":[]}
+
+HTTP/1.1 200 Okay
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:39:31 GMT
+content-type: application/json; charset=utf-8
+content-length: 2
+connection: close
+status: 200 Okay
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4996
+x-ratelimit-reset: 1541729149
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: repo
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D05A:6FD7:4A0FCCA:9AB6F49:5BE4E553
+
+{}

--- a/test/fixtures/api.github.com-443/comment-missing-assignee-get-comments
+++ b/test/fixtures/api.github.com-443/comment-missing-assignee-get-comments
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16784/comments
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-missing-assignee-get-labels
+++ b/test/fixtures/api.github.com-443/comment-missing-assignee-get-labels
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16784/labels
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-missing-assignee-patch-assignee
+++ b/test/fixtures/api.github.com-443/comment-missing-assignee-patch-assignee
@@ -1,0 +1,31 @@
+PATCH /repos/web-platform-tests/wpt/issues/16784
+accept: application/vnd.github.black-cat-preview+json
+body: {\"assignees\":[\"Hexcles\"]}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-missing-assignee-post-comments
+++ b/test/fixtures/api.github.com-443/comment-missing-assignee-post-comments
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16784/comments
+accept: application/vnd.github.black-cat-preview+json
+body: {\"body\":\"There are no reviewers for this pull request. Please reach out on W3C\'s irc server (irc.w3.org, port 6665) on channel #testing ([web client](http://irc.w3.org/?channels=testing)) to get help with this. Thank you!\"}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-missing-assignee-post-labels
+++ b/test/fixtures/api.github.com-443/comment-missing-assignee-post-labels
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16784/labels
+accept: application/vnd.github.black-cat-preview+json
+body: [\"status:needs-reviewers\"]
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+["status:needs-reviewers"]

--- a/test/fixtures/api.github.com-443/comment-no-reviewers-get-comments
+++ b/test/fixtures/api.github.com-443/comment-no-reviewers-get-comments
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16790/comments
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-no-reviewers-get-labels
+++ b/test/fixtures/api.github.com-443/comment-no-reviewers-get-labels
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16790/labels
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-no-reviewers-post-comments
+++ b/test/fixtures/api.github.com-443/comment-no-reviewers-post-comments
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16790/comments
+accept: application/vnd.github.black-cat-preview+json
+body: {\"body\":\"There are no reviewers for this pull request. Please reach out on W3C\'s irc server (irc.w3.org, port 6665) on channel #testing ([web client](http://irc.w3.org/?channels=testing)) to get help with this. Thank you!\"}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-no-reviewers-post-labels
+++ b/test/fixtures/api.github.com-443/comment-no-reviewers-post-labels
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16790/labels
+accept: application/vnd.github.black-cat-preview+json
+body: [\"status:needs-reviewers\"]
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+["status:needs-reviewers"]

--- a/test/fixtures/api.github.com-443/comment-no-write-access-get-comments
+++ b/test/fixtures/api.github.com-443/comment-no-write-access-get-comments
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16788/comments
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-no-write-access-get-labels
+++ b/test/fixtures/api.github.com-443/comment-no-write-access-get-labels
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16788/labels
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-no-write-access-post-comments
+++ b/test/fixtures/api.github.com-443/comment-no-write-access-post-comments
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16788/comments
+accept: application/vnd.github.black-cat-preview+json
+body: {\"body\":\"No reviewer on this pull request has write-access to the repository. Please reach out on W3C\'s irc server (irc.w3.org, port 6665) on channel #testing ([web client](http://irc.w3.org/?channels=testing)) to get help with this. Thank you!\"}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true

--- a/test/fixtures/api.github.com-443/comment-no-write-access-post-labels
+++ b/test/fixtures/api.github.com-443/comment-no-write-access-post-labels
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16788/labels
+accept: application/vnd.github.black-cat-preview+json
+body: [\"status:needs-collaborator\"]
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+["status:needs-reviewers"]

--- a/test/fixtures/api.github.com-443/comment-webkit-prs-get-comments
+++ b/test/fixtures/api.github.com-443/comment-webkit-prs-get-comments
@@ -1,0 +1,30 @@
+GET /repos/web-platform-tests/wpt/issues/16781/comments
+accept: application/vnd.github.black-cat-preview+json
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+[]

--- a/test/fixtures/api.github.com-443/comment-webkit-prs-post-comments
+++ b/test/fixtures/api.github.com-443/comment-webkit-prs-post-comments
@@ -1,0 +1,31 @@
+POST /repos/web-platform-tests/wpt/issues/16781/comments
+accept: application/vnd.github.black-cat-preview+json
+body: {\"body\":\"This patch has been exported from WebKit; it will be approved automatically once the downstream patch is r+.\"}
+
+HTTP/1.1 200 OK
+server: GitHub.com
+date: Fri, 09 Nov 2018 01:35:07 GMT
+content-type: application/json; charset=utf-8
+content-length: 1576
+connection: close
+status: 200 OK
+x-ratelimit-limit: 5000
+x-ratelimit-remaining: 4997
+x-ratelimit-reset: 1541729149
+cache-control: private, max-age=60, s-maxage=60
+vary: Accept, Authorization, Cookie, X-GitHub-OTP
+etag: "9951cb2c99002d7409b77ede48c39c33"
+x-oauth-scopes: public_repo
+x-accepted-oauth-scopes: 
+x-github-media-type: github.v3; param=black-cat-preview; format=json
+access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type
+access-control-allow-origin: *
+strict-transport-security: max-age=31536000; includeSubdomains; preload
+x-frame-options: deny
+x-content-type-options: nosniff
+x-xss-protection: 1; mode=block
+referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
+content-security-policy: default-src 'none'
+x-github-request-id: D028:6FD7:49FC6BA:9A8F236:5BE4E44A
+
+true


### PR DESCRIPTION
WebKit PRs are considered exported PRs and are approved automatically,
however unlike other vendors they want to wait for r+ downstream before
approving the PR. As such, the current logic accidentally assigns WebKit
PRs an assignee and reviewers when they shouldn't.
    
See https://github.com/web-platform-tests/wpt/pull/23761#issuecomment-633718440