### PR TITLE
Switch from Renovate to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: monthly

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "extends": [
-    "config:base",
-    ":preserveSemverRanges"
-  ]
-}


### PR DESCRIPTION
We use Dependabot for most other repos in web-platform-tests.