### PR TITLE
Run GitHub Actions on latest Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3


### PR DESCRIPTION
We don't do anything special so it's unlikely an upgrade of
ubuntu-latest will break tests. On the other hand, ubuntu-18.04 is
certain to be retired at some point, which would break us.