### PR TITLE
Fix unbound logger.info

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,10 +64,10 @@ app.post('/github-hook', function (req, res) {
             } catch(e) {
                 return;
             }
-            if (!filter.event(body, logger.info)) {
+            if (!filter.event(body, logger.info.bind(logger))) {
                 return;
             }
-            if (!filter.pullRequest(body.pull_request, logger.info)) {
+            if (!filter.pullRequest(body.pull_request, logger.info.bind(logger))) {
                 return;
             }
 


### PR DESCRIPTION
Taking the value of logger.info and later trying to invoke it doesn't
work, and results in the error "attempt to log with an unbound log
method" in GCP logs.