### PR TITLE
Make logging depend on the environment

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -5,15 +5,17 @@
 const bunyan = require('bunyan'),
       {LoggingBunyan} = require('@google-cloud/logging-bunyan');
 
-const loggingBunyan = new LoggingBunyan();
-const logger = bunyan.createLogger({
-  name: 'wpt-pr-bot',
-  streams: [
-    // Log to the console at 'info' and above
-    {stream: process.stdout, level: 'info'},
-    // And log to Stackdriver Logging, logging at 'debug' and above
-    loggingBunyan.stream('debug'),
-  ],
-});
+const streams = [];
+
+if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  // And log to Stackdriver Logging, logging at 'debug' and above
+  const loggingBunyan = new LoggingBunyan();
+  streams.push(loggingBunyan.stream('debug'));
+} else {
+  // Log to the console at 'info' and above
+  streams.push({stream: process.stdout, level: 'info'});
+}
+
+const logger = bunyan.createLogger({name: 'wpt-pr-bot', streams});
 
 module.exports = logger;


### PR DESCRIPTION
This is to avoid unconditionally trying to use
@google-cloud/logging-bunyan, which results in a "Unable to detect a
Project Id in the current environment" error while running tests.