### PR TITLE
Fix WebKit export auto-approvals when bug is fixed

### DIFF
--- a/lib/metadata/webkit.js
+++ b/lib/metadata/webkit.js
@@ -41,7 +41,7 @@ exports.flags = function(issue) {
                         }
                     }
                     if (change.field_name == "resolution") {
-                        if (change.added.includes("FIXED") && history_item.who == "commit-queue@webkit.org" ) {
+                        if (change.added.includes("FIXED") && history_item.who == "ews-feeder@webkit.org" ) {
                             flags.reviewed = true;
                             flags.inCommit = true;
                         }


### PR DESCRIPTION
ews-feeder@webkit.org is now the email that comments when resolving bugs to FIXED.