### PR TITLE
Upgrade to Node.js 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
     - run: npm ci
     - run: npm test

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Development
 =====
 
 Requirements:
-- Node v16
+- Node v18
 
 ### Getting Started
 
@@ -44,12 +44,7 @@ npm run test
 Deploying
 =====
 
-1. Get the secrets:
-   - ```bash
-     npm run gcp-build
-     ```
-   - TODO: Can remove step 1 after #213
-2. Deploy:
+1. Deploy:
    - ```bash
      # Create a variable to represent the version
      VERSION_ID="rev-$(git rev-parse --short HEAD)"
@@ -57,19 +52,19 @@ Deploying
      # Deploy the new version but do not promote it
      gcloud --project=wpt-pr-bot app deploy --no-promote -v "${VERSION_ID}"
      ```
-3. Check the logs for the instance
+2. Check the logs for the instance
    - ```bash
      gcloud --project=wpt-pr-bot app logs tail -s default -v "${VERSION_ID}"
      ```
    - Check to make sure that the app has started. It should
      [print](https://github.com/web-platform-tests/wpt-pr-bot/blob/main/index.js#L121)
      `App started in ....`
-4. Redirect traffic to the new version.
+3. Redirect traffic to the new version.
    - ```bash
      gcloud --project=wpt-pr-bot app services set-traffic default \
          --splits="${VERSION_ID}"=1
      ```
-5. Keep only 2 versions of the app (VERSION_ID and the previous version).
+4. Keep only 2 versions of the app (VERSION_ID and the previous version).
    To delete older versions:
    - ```bash
      # Check the number of versions. There should only be two.
@@ -79,6 +74,6 @@ Deploying
      gcloud --project=wpt-pr-bot app versions delete \
          ${REALLY_OLD_VERSION_ID} --service=default
      ```
-6. Monitor the "Recent Deliveries"
+5. Monitor the "Recent Deliveries"
 [tab](https://github.com/web-platform-tests/wpt/settings/hooks/161784539?tab=deliveries)
 in wpt. If there are any failures, use the command in step 3 to tail the logs.

--- a/app.yaml
+++ b/app.yaml
@@ -1,3 +1,3 @@
 # https://cloud.google.com/appengine/docs/standard/nodejs/runtime
 
-runtime: nodejs16
+runtime: nodejs18


### PR DESCRIPTION
This version will be supported by GCP until 2025-04-30: https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#nodejs Also clean up the README.md file since #213 was merged.